### PR TITLE
Support Homebrew's prefixing gnu commands with 'g'

### DIFF
--- a/macos-guest-virtualbox.sh
+++ b/macos-guest-virtualbox.sh
@@ -129,6 +129,13 @@ fi
 }
 
 function check_dependencies() {
+# Homebrew installs the gnu coreutils with 'g' prefixes by default
+if [ -n "$(gcsplit --help 2>/dev/null)" ]; then
+  csplit() {
+    gcsplit "$@"
+  }
+fi
+
 # check if running on macOS and non-GNU coreutils
 if [ -n "$(sw_vers 2>/dev/null)" -a -z "$(csplit --help 2>/dev/null)" ]; then
     echo ""


### PR DESCRIPTION
On my Mac, macos-guest-virtualbox.sh exits with this error:

```
macOS detected. Please use a package manager such as homebrew, nix, or MacPorts.
Please make sure the following packages are installed and that
their path is in the PATH variable:
bash  coreutils  wget  unzip  dmg2img
Please make sure bash and coreutils are the GNU variant.
```

It's because Homebrew installs coreutils with a 'g' prefix. If they exist, we might as well use them.

There are a number of ways of fixing this (a global variable, a modularized csplit function, ...). If the idea is good but the implementation is wrong, happy to rewrite however you suggest.