### PR TITLE
Fix the issue that VirtualBox can't adapt to 1366x768

### DIFF
--- a/macos-guest-virtualbox.sh
+++ b/macos-guest-virtualbox.sh
@@ -566,7 +566,7 @@ VBoxManage setextradata "${vmname}" \
 VBoxManage setextradata "${vmname}" \
  "VBoxInternal/Devices/smc/0/Config/GetKeyFromRealSMC" 0
 VBoxManage setextradata "${vmname}" \
- "VBoxInternal2/EfiGraphicsResolution" "${resolution}"
+ "CustomVideoMode1" "${resolution}x32"
 }
 
 # QWERTY-to-scancode dictionary. Hex scancodes, keydown and keyup event.


### PR DESCRIPTION
Currently, the config can't make VBox to adapt the 1366x768 resolution.
I replaced the tweak a little bit and it is tested to work on my machine with 1366x768 resolution as well as other resolutions.